### PR TITLE
Add templatetag for Google+ sharing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Django Social Share
 ======================================
 
-Provides tempatetags for 'Tweet This' and 'Share this on Facebook'.
+Provides tempatetags for 'Tweet This', 'Share this on Facebook', and 'Share on Google+'.
 
 Installation
 -------------
@@ -23,6 +23,8 @@ Usage
 ::
 
   {% post_to_facebook <object_or_url> <link_text> %}
+  
+  {% post_to_gplus <object_or_url> <link_text> %}
 
   {% post_to_twitter <text_to_post> <object_or_url> <link_text> %}
 
@@ -44,11 +46,18 @@ Will add a ``tweet_url`` variable to the context, containing the URL for the Twi
 
 Will add a ``facebook_url`` variable to the context, containing the URL for the Facebook sharer popup.
 
+::
+
+  {% post_to_gplus_url <object_or_url> %}
+
+Will add a ``gplus_url`` variable to the context, containing the URL for the Google+ sharer popup.
+
 Example::
 
   {% load social_share %}
   
   {% post_to_facebook object_or_url "Post to Facebook!" %}
   {% post_to_twitter "New Song: {{object.title}}. Check it out!" object_or_url "Post to Twitter" %}
+  {% post_to_gplus object_or_url "Post to Google+!" %}
 
-Templates are in ``django_social_share/templatetags/post_to_twitter.html`` and ``django_social_share/templatetags/post_to_facebook.html``. You can override them to suit your mileage.
+Templates are in ``django_social_share/templatetags/post_to_twitter.html``, ``django_social_share/templatetags/post_to_facebook.html`` and ``django_social_share/templatetags/post_to_gplus.html``. You can override them to suit your mileage.

--- a/django_social_share/templates/django_social_share/templatetags/post_to_gplus.html
+++ b/django_social_share/templates/django_social_share/templatetags/post_to_gplus.html
@@ -1,0 +1,3 @@
+<div class="gplus-this">
+    <a href="{{ gplus_url }}" target="_blank">{{link_text}}</a>
+</div>

--- a/django_social_share/templatetags/social_share.py
+++ b/django_social_share/templatetags/social_share.py
@@ -16,7 +16,7 @@ register = template.Library()
 
 TWITTER_ENDPOINT = 'http://twitter.com/intent/tweet?text=%s'
 FACEBOOK_ENDPOINT = 'http://www.facebook.com/sharer/sharer.php?u=%s'
-GPLUS_ENDPOINt = 'http://plus.google.com/share?url=%s'
+GPLUS_ENDPOINT = 'http://plus.google.com/share?url=%s'
 
 def compile_text(context, text):
     ctx = template.context.Context(context)

--- a/django_social_share/templatetags/social_share.py
+++ b/django_social_share/templatetags/social_share.py
@@ -16,7 +16,7 @@ register = template.Library()
 
 TWITTER_ENDPOINT = 'http://twitter.com/intent/tweet?text=%s'
 FACEBOOK_ENDPOINT = 'http://www.facebook.com/sharer/sharer.php?u=%s'
-
+GPLUS_ENDPOINt = 'http://plus.google.com/share?url=%s'
 
 def compile_text(context, text):
     ctx = template.context.Context(context)
@@ -90,5 +90,20 @@ def post_to_facebook_url(context, obj_or_url=None):
 @register.inclusion_tag('django_social_share/templatetags/post_to_facebook.html', takes_context=True)
 def post_to_facebook(context, obj_or_url=None, link_text='Post to Facebook'):
     context = post_to_facebook_url(context, obj_or_url)
+    context['link_text'] = link_text
+    return context
+
+
+@register.simple_tag(takes_context=True)
+def post_to_gplus_url(context, obj_or_url=None):
+    request = context.get('request', MockRequest())
+    url = _build_url(request, obj_or_url)
+    context['gplus_url'] = GPLUS_ENDPOINT % urlencode(url)
+    return context
+
+
+@register.inclusion_tag('django_social_share/templatetags/post_to_gplus.html', takes_context=True)
+def post_to_gplus(context, obj_or_url=None, link_text='Post to Google+'):
+    context = post_to_gplus_url(context, obj_or_url)
     context['link_text'] = link_text
     return context


### PR DESCRIPTION
We use django-social-share in a production site, and Google+ sharing was missing (Facebook, Twitter and Google+ share links are often shown together) - this pull request adds Google+ sharer support.