### PR TITLE
Minor refactoring.

### DIFF
--- a/django_social_share/templatetags/social_share.py
+++ b/django_social_share/templatetags/social_share.py
@@ -12,11 +12,14 @@ try:
 except ImportError:
     DJANGO_BITLY = False
 
+
 register = template.Library()
+
 
 TWITTER_ENDPOINT = 'http://twitter.com/intent/tweet?text=%s'
 FACEBOOK_ENDPOINT = 'http://www.facebook.com/sharer/sharer.php?u=%s'
 GPLUS_ENDPOINT = 'http://plus.google.com/share?url=%s'
+
 
 def compile_text(context, text):
     ctx = template.context.Context(context)
@@ -24,7 +27,8 @@ def compile_text(context, text):
 
 
 class MockRequest(object):
-    def build_absolute_uri(self, relative_url):
+    @staticmethod
+    def build_absolute_uri(relative_url):
         if relative_url.startswith('http'):
             return relative_url
         current_site = Site.objects.get_current()


### PR DESCRIPTION
Declared the build_absolute_uri function as static since it wasn't being referenced by self. Spaces to comply with pep-8.