### PR TITLE
Add a blank target to the Twitter link

### DIFF
--- a/django_social_share/templates/django_social_share/templatetags/post_to_twitter.html
+++ b/django_social_share/templates/django_social_share/templatetags/post_to_twitter.html
@@ -1,3 +1,3 @@
 <div class="tweet-this">
-    <a href="{{ tweet_url }}" class="meta-act-link meta-tweet">{{link_text}}</a>
+    <a href="{{ tweet_url }}" class="meta-act-link meta-tweet" target="_blank">{{link_text}}</a>
 </div>

--- a/django_social_share/templatetags/social_share.py
+++ b/django_social_share/templatetags/social_share.py
@@ -132,7 +132,7 @@ def send_email(context, subject, text, obj_or_url=None, link_text='Share via ema
 @register.simple_tag(takes_context=True)
 def post_to_linkedin_url(context, title, obj_or_url=None):
     request = context['request']
-    title = compile_text(context, title[:200]) # 200 char limit
+    title = compile_text(context, title[:200])  # 200 char limit
     url = _build_url(request, obj_or_url)
     context['linkedin_url'] = mark_safe(LINKEDIN_ENDPOINT % (urlencode(title), urlencode(url)))
     return context

--- a/django_social_share/tests/tests.py
+++ b/django_social_share/tests/tests.py
@@ -16,7 +16,7 @@ class TemplateTagsTest(TestCase):
     def test_twitter(self):
         template = Template("{% load social_share %} {% post_to_twitter text url %}")
         result = template.render(self.context)
-        expected = ' <div class="tweet-this">\n    <a href="http://twitter.com/intent/tweet?text=example%20http%3A//example.com" class="meta-act-link meta-tweet">Post to Twitter</a>\n</div>\n'
+        expected = ' <div class="tweet-this">\n    <a href="http://twitter.com/intent/tweet?text=example%20http%3A//example.com" class="meta-act-link meta-tweet" target="_blank">Post to Twitter</a>\n</div>\n'
         self.assertEqual(result, expected)
 
     def test_facebook(self):

--- a/django_social_share/tests/tests.py
+++ b/django_social_share/tests/tests.py
@@ -16,7 +16,7 @@ class TemplateTagsTest(TestCase):
     def test_twitter(self):
         template = Template("{% load social_share %} {% post_to_twitter text url %}")
         result = template.render(self.context)
-        expected = ' <div class="tweet-this">\n    <a href="http://twitter.com/intent/tweet?text=example%20http%3A//example.com" class="meta-act-link meta-tweet" target="_blank">Post to Twitter</a>\n</div>\n'
+        expected = ' <div class="tweet-this">\n  <a href="http://twitter.com/intent/tweet?text=example%20http%3A//example.com" class="meta-act-link meta-tweet" target="_blank">Post to Twitter</a>\n</div>'
         self.assertEqual(result, expected)
 
     def test_facebook(self):


### PR DESCRIPTION
Added a ‘blank target’ to the Twitter <a href> link tag.