### PR TITLE
Bugfix: unqualified URL returned if bitly fails

### DIFF
--- a/django_social_share/templatetags/social_share.py
+++ b/django_social_share/templatetags/social_share.py
@@ -33,7 +33,14 @@ def _build_url(request, obj_or_url):
     if obj_or_url is not None:
         if isinstance(obj_or_url, Model):
             if DJANGO_BITLY:
-                return bitlify(obj_or_url)
+                import re
+                url = bitlify(obj_or_url)  # type: str
+                if not re.match(r'^https?://bit\.ly/', url):
+                    return request.build_absolute_uri(
+                        obj_or_url.get_absolute_url()
+                    )
+                else:
+                    return url
             else:
                 return request.build_absolute_uri(obj_or_url.get_absolute_url())
         else:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = '1.1.1'
+VERSION = '1.1.2'
 
 
 def read(fname):


### PR DESCRIPTION
When using a domain not accepted by bitly (such as localhost:8000),
a link without scheme and netloc is returned. This applies to any error
generated, so also on outages.

Instead, use the already present logic to build the fully qualified URL
if we're reasonably sure the process failed.