### PR TITLE
Updated WHATSAPP_ENDPOINT

### DIFF
--- a/django_social_share/templatetags/social_share.py
+++ b/django_social_share/templatetags/social_share.py
@@ -26,7 +26,7 @@ MAIL_ENDPOINT = 'mailto:?subject=%s&body=%s'
 LINKEDIN_ENDPOINT = 'https://www.linkedin.com/shareArticle?mini=true&title=%s&url=%s'
 REDDIT_ENDPOINT = 'https://www.reddit.com/submit?title=%s&url=%s'
 TELEGRAM_ENDPOINT = 'https://t.me/share/url?text=%s&url=%s'
-WHATSAPP_ENDPOINT = 'https://wa.me/?text=%s'
+WHATSAPP_ENDPOINT = 'https://api.whatsapp.com/send?text=%s'
 
 
 BITLY_REGEX = re.compile(r'^https?://bit\.ly/')


### PR DESCRIPTION
I updated the Whatsapp Endpoint. In my experience the https://wa.me URL sometimes redirects to https://api.whatsapp.com/error with an error message. The URL https://api.whatsapp.com/send seems more reliable.