### PR TITLE
Add "copy link" feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,7 +139,7 @@ Will add a ``pinterest_url`` variable to the context, containing the URL for the
 
   {% copy_to_clipboard <object_or_url> <link_text> <link_class> %}
 
-will add a ``copy_url``` variable to the context, containing the URL for the link to copy.
+will add a ``copy_url`` variable to the context, containing the URL for the link to copy.
 
 Example::
 
@@ -155,7 +155,7 @@ Example::
   {% post_to_whatsapp object_or_url "Share via WhatsApp" %}
   {% save_to_pinterest object_or_url %}
   {% add_pinterest_script %} // Required for save_to_pinterest. Add to the end of body tag.
-  {% copy_to_clipboard object_or_url%}
+  {% copy_to_clipboard object_or_url "Copy to clipboard!" %}
   {% add_copy_script %} // Required for copy_to_clipboard. Add to the end of body tag.
 
 .. _templates:

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ Provides templatetags for:
 * 'Share on WhatsApp'
 * 'mailto://'.
 * 'Save to Pinterest'
+* 'Copy to Clipboard'
 
 Plain HTML templates_ are provided for your convenience, but you can override them to provide your own look and feel.
 
@@ -74,6 +75,10 @@ Usage
 
   {% add_pinterest_script %}
 
+  {% copy_to_clipboard <object_or_url> <link_text> <link_class> %}
+
+  {% add_copy_script %}
+
 ``<text_to_post>`` may contain any valid Django Template code. Note that Facebook does not support this anymore.
 
 ``<object_or_url>`` is optional (except Telegram). If you pass a django model instance, it will use its ``get_absolute_url`` method. Additionally, if you have ``django_bitly`` installed, it will use its shortUrl on Twitter.
@@ -130,6 +135,12 @@ Will add a ``whatsapp_url`` variable to the context, containing the URL for the 
 
 Will add a ``pinterest_url`` variable to the context, containing the URL for the Pinterest sharer.
 
+::
+
+  {% copy_to_clipboard <object_or_url> <link_text> <link_class> %}
+
+will add a ``copy_url``` variable to the context, containing the URL for the link to copy.
+
 Example::
 
   {% load social_share %}
@@ -144,6 +155,8 @@ Example::
   {% post_to_whatsapp object_or_url "Share via WhatsApp" %}
   {% save_to_pinterest object_or_url %}
   {% add_pinterest_script %} // Required for save_to_pinterest. Add to the end of body tag.
+  {% copy_to_clipboard object_or_url%}
+  {% add_copy_script %} // Required for copy_to_clipboard. Add to the end of body tag.
 
 .. _templates:
 
@@ -162,6 +175,8 @@ Templates are in:
 * ``django_social_share/templatetags/post_to_whatsapp.html``.
 * ``django_social_share/templatetags/save_to_pinterest.html``.
 * ``django_social_share/templatetags/pinterest_script.html``.
+* ``django_social_share/templatetags/copy_to_clipboard.html``.
+* ``django_social_share/templatetags/copy_script.html``.
   
 You can override them to suit your mileage.
 

--- a/django_social_share/templates/django_social_share/templatetags/copy_script.html
+++ b/django_social_share/templates/django_social_share/templatetags/copy_script.html
@@ -1,0 +1,1 @@
+<script></script>

--- a/django_social_share/templates/django_social_share/templatetags/copy_script.html
+++ b/django_social_share/templates/django_social_share/templatetags/copy_script.html
@@ -1,1 +1,44 @@
-<script></script>
+<script>
+  function copyTextToClipboard(text) {
+    var textArea = document.createElement("textarea");
+
+    // Place in the top-left corner of screen regardless of scroll position.
+    textArea.style.position = "fixed";
+    textArea.style.top = 0;
+    textArea.style.left = 0;
+
+    textArea.style.width = "2em";
+    textArea.style.height = "2em";
+
+    textArea.style.padding = 0;
+
+    // Clean up any borders.
+    textArea.style.border = "none";
+    textArea.style.outline = "none";
+    textArea.style.boxShadow = "none";
+
+    // Avoid flash of the white box if rendered for any reason.
+    textArea.style.background = "transparent";
+
+    textArea.value = text;
+
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+
+    try {
+      document.execCommand("copy");
+    } catch (err) {
+      console.log("unable to copy");
+    }
+
+    document.body.removeChild(textArea);
+  }
+
+  var copyBtn = document.querySelector('[data-copy-btn="buttonCopy"]');
+
+  copyBtn.addEventListener("click", function (event) {
+    var url = copyBtn.getAttribute("data-copy-url");
+    copyTextToClipboard(url);
+  });
+</script>

--- a/django_social_share/templates/django_social_share/templatetags/copy_to_clipboard.html
+++ b/django_social_share/templates/django_social_share/templatetags/copy_to_clipboard.html
@@ -1,0 +1,3 @@
+<div class="copy-this">
+    <button data-copy-btn="buttonCopy" data-copy-url="{{ copy_url }}" class="{{ link_class }}">{{link_text}}</button>
+</div>

--- a/django_social_share/templates/django_social_share/templatetags/copy_to_clipboard.html
+++ b/django_social_share/templates/django_social_share/templatetags/copy_to_clipboard.html
@@ -1,3 +1,3 @@
 <div class="copy-this">
-    <button data-copy-btn="buttonCopy" data-copy-url="{{ copy_url }}" class="{{ link_class }}">{{link_text}}</button>
+    <button data-copy-btn="buttonCopy" data-copy-url="{{ copy_url }}" class="{{ link_class }}">{{ link_text }}</button>
 </div>

--- a/django_social_share/templatetags/social_share.py
+++ b/django_social_share/templatetags/social_share.py
@@ -241,3 +241,22 @@ def save_to_pinterest(context, obj_or_url=None, pin_count=False, link_class=''):
 @register.inclusion_tag('django_social_share/templatetags/pinterest_script.html', takes_context=False)
 def add_pinterest_script():
     pass
+
+@register.simple_tag(takes_context=True)
+def copy_to_clipboard_url(context, obj_or_url=None):
+    request = context['request']
+    url = _build_url(request, obj_or_url)
+    context['copy_url'] = url
+    return context
+
+@register.inclusion_tag('django_social_share/templatetags/copy_to_clipboard.html', takes_context=True)
+def copy_to_clipboard(context, obj_or_url, link_text='', link_class=''):
+    context = copy_to_clipboard_url(context, obj_or_url)
+    
+    context['link_class'] = link_class
+    context['link_text'] = link_text or 'Copy to clipboard'
+    return context
+
+@register.inclusion_tag('django_social_share/templatetags/copy_script.html', takes_context=False)
+def add_copy_script():
+    pass

--- a/django_social_share/tests/tests.py
+++ b/django_social_share/tests/tests.py
@@ -82,6 +82,11 @@ class TemplateTagsTest(TestCase):
         expected = ' <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>\n'
         self.assertEqual(result, expected)
 
+    def test_clipboard(self):
+        template = Template("{% load social_share %} {% copy_to_clipboard url %}")
+        result = template.render(self.context)
+        expected = ' <div class="copy-this">\n    <button data-copy-btn="buttonCopy" data-copy-url="http://example.com" class="">Copy to clipboard</button>\n</div>\n'
+        self.assertEqual(result, expected)
 
     def test_twitter_with_class(self):
         template = Template("{% load social_share %} {% post_to_twitter text url  link_text link_class %}")
@@ -135,4 +140,10 @@ class TemplateTagsTest(TestCase):
         template = Template("{% load social_share %} {% save_to_pinterest url  False link_class %}")
         result = template.render(self.context)
         expected = ' <div class="pinterest-this example_class">\n    <a data-pin-do="buttonPin" href="https://www.pinterest.com/pin/create/button/?url=http%3A//example.com" target="_blank"></a>\n</div>\n'
+        self.assertEqual(result, expected)
+
+    def test_clipboard_with_class(self):
+        template = Template("{% load social_share %} {% copy_to_clipboard url text link_class %}")
+        result = template.render(self.context)
+        expected = ' <div class="copy-this">\n    <button data-copy-btn="buttonCopy" data-copy-url="http://example.com" class="example_class">example</button>\n</div>\n'
         self.assertEqual(result, expected)


### PR DESCRIPTION
Made this feature possible by using JavaScript. The template tag creates the link from the given `object_or_url` and adds it to the html attribute `data-copy-url`. When `Copy to clipboard` button is clicked, the javascript script copies the url from the attribute above `data-copy-url` to the clipboard, this copied can be pasted anywhere on your device.
The Js script can be further extended to add functionality for multiple `copy_to_clipboard` buttons supporting e.g. a blog site with multiple articles in a single page